### PR TITLE
Changes to edge partitioning

### DIFF
--- a/sparsetiling/include/partitioner.h
+++ b/sparsetiling/include/partitioner.h
@@ -19,4 +19,8 @@
  */
 void partition (inspector_t* insp);
 
+#ifdef SLOPE_METIS
+void get_adjncy_and_offsets(map_t* map, int** adjncy, int** offsets);
+#endif
+
 #endif


### PR DESCRIPTION
This has changes related to edge partitioning since current offset and adjacency array creation for edge partitioning needed some changes. Edge partitioning was done after creating a line graph considering edges as nodes. This was tested using airfoil and mg-cfd.